### PR TITLE
fix: Correct JSX structure in producers page

### DIFF
--- a/src/app/producers/page.tsx
+++ b/src/app/producers/page.tsx
@@ -662,11 +662,10 @@ export default function ProducerHub() {
                   </div>
                 </div>
               ))}
-            </div>
 
               {/* Empty State */}
               {filteredProducers.length === 0 && (
-                <div className={`text-center py-16 rounded-xl border ${
+                <div className={`text-center py-16 rounded-xl border col-span-full ${
                   theme === "dark"
                     ? "bg-zinc-950 border-zinc-800"
                     : "bg-white border-gray-300"


### PR DESCRIPTION
Fixed misplaced closing div tag that was causing syntax error. The empty state component should be inside the grid container, not outside it.

- Removed extra closing </div> tag
- Moved empty state inside grid container
- Added col-span-full to empty state for proper grid layout