### PR TITLE
fix: Correct JSX structure in beats and equipment pages

### DIFF
--- a/src/app/beats/page.tsx
+++ b/src/app/beats/page.tsx
@@ -613,7 +613,6 @@ export default function BeatMarketplace() {
                   </div>
                 </div>
               ))}
-            </div>
 
               {/* Empty State */}
               {filteredBeats.length === 0 && (

--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -632,7 +632,6 @@ export default function GearMarketplace() {
                   </div>
                 </div>
               ))}
-            </div>
 
               {/* Empty State */}
               {filteredGear.length === 0 && (


### PR DESCRIPTION
Fixed misplaced closing div tags causing syntax errors in beats and equipment marketplace pages.

**Changes:**
- Moved empty state inside respective containers
- Removed duplicate closing div tags
- Ensured proper JSX hierarchy

All marketplace pages now have consistent and valid JSX structure.