### PR TITLE
fix: use real producer data instead of hardcoded values and fix routing

### DIFF
--- a/src/app/api/producers/route.ts
+++ b/src/app/api/producers/route.ts
@@ -44,6 +44,8 @@ export async function GET(req: NextRequest) {
             location: true,
             verified: true,
             email: true,
+            followersCount: true,
+            followingCount: true,
             uploadedBeats: {
               where: { isActive: true },
               select: {
@@ -105,6 +107,11 @@ export async function GET(req: NextRequest) {
           imageUrl: profile.user.avatar,
           bio: profile.user.bio,
           location: profile.user.location,
+          verified: profile.user.verified,
+          followersCount: profile.user.followersCount || 0,
+          followingCount: profile.user.followingCount || 0,
+          genres: profile.genres || [],
+          specialties: profile.specialties || [],
           studios: studios.map((studio) => ({
             id: studio.id,
             name: studio.name,

--- a/src/hooks/useProducers.ts
+++ b/src/hooks/useProducers.ts
@@ -8,6 +8,12 @@ export interface Producer {
   email: string;
   imageUrl: string | null;
   bio: string | null;
+  location: string | null;
+  verified: boolean;
+  followersCount: number;
+  followingCount: number;
+  genres: string[];
+  specialties: string[];
   studios: {
     id: string;
     name: string;


### PR DESCRIPTION
- Changed producer IDs from converted numbers to proper UUID strings
- Removed all hardcoded/random values (ratings, online status, etc.)
- Use real data from API: followersCount, verified, genres, specialties
- Show verified badge instead of fake rating
- Display real follower counts and beat counts
- Producer cards now link to correct detail pages with UUID
- Updated API to return producer profile data (genres, followers, etc.)
- Fixed all property references to match new API structure