### PR TITLE
fix: correct Activity model reference in service request creation

### DIFF
--- a/src/app/api/service-requests/route.ts
+++ b/src/app/api/service-requests/route.ts
@@ -176,16 +176,14 @@ export async function POST(req: NextRequest) {
       });
 
       // Create activity log entry
-      await prisma.activityLog.create({
+      await prisma.activity.create({
         data: {
           userId: user.id,
-          action: "SERVICE_REQUEST_CREATED",
-          details: `Requested services from ${producer.fullName || producer.username} for project: ${projectTitle}`,
-          metadata: {
-            serviceRequestId: serviceRequest.id,
-            producerId,
-            projectTitle,
-          },
+          type: "JOB_REQUEST_SENT",
+          title: "Service Request Sent",
+          description: `Requested services from ${producer.fullName || producer.username} for project: ${projectTitle}`,
+          referenceId: serviceRequest.id,
+          referenceType: "SERVICE_REQUEST",
         },
       });
 


### PR DESCRIPTION
Fixed TypeError where prisma.activityLog.create was being called but the model is named Activity in the schema. Updated to use correct model name and field mappings (type, title, description instead of action, details, metadata).